### PR TITLE
Fixed issue where app got stuck if signing up with duplicate email

### DIFF
--- a/lib/src/screens/auth/blocs/sign_up_bloc/sign_up_bloc.dart
+++ b/lib/src/screens/auth/blocs/sign_up_bloc/sign_up_bloc.dart
@@ -13,10 +13,11 @@ class SignUpBloc extends Bloc<SignUpEvent, SignUpState> {
       emit(SignUpLoading());
       try {
         MyUser myUser = await _userRepository.signUp(event.user, event.password);
+
         await _userRepository.setUserData(myUser);
         emit(SignUpSuccess());
       } catch (e) {
-        emit(SignUpFailure());
+        emit(SignUpFailure(error: e.toString()));
       }
     });
   }

--- a/lib/src/screens/auth/blocs/sign_up_bloc/sign_up_bloc.dart
+++ b/lib/src/screens/auth/blocs/sign_up_bloc/sign_up_bloc.dart
@@ -17,7 +17,12 @@ class SignUpBloc extends Bloc<SignUpEvent, SignUpState> {
         await _userRepository.setUserData(myUser);
         emit(SignUpSuccess());
       } catch (e) {
-        emit(SignUpFailure(error: e.toString()));
+         String errorMessage = e.toString();
+        int colonIndex = errorMessage.indexOf(':');
+        if (colonIndex != -1 && colonIndex + 1 < errorMessage.length) {
+          errorMessage = errorMessage.substring(colonIndex + 1).trim();
+        }
+        emit(SignUpFailure(error: errorMessage));
       }
     });
   }

--- a/lib/src/screens/auth/blocs/sign_up_bloc/sign_up_state.dart
+++ b/lib/src/screens/auth/blocs/sign_up_bloc/sign_up_state.dart
@@ -7,7 +7,14 @@ sealed class SignUpState extends Equatable {
   List<Object> get props => [];
 }
 
-final class SignUpInitial extends SignUpState {}
+class SignUpInitial extends SignUpState {}
 class SignUpLoading extends SignUpState {}
-class SignUpFailure extends SignUpState {}
+class SignUpFailure extends SignUpState {
+  final String error;
+
+  const SignUpFailure({required this.error});
+
+  @override
+  List<Object> get props => [error];
+}
 class SignUpSuccess extends SignUpState {}

--- a/lib/src/screens/auth/views/sign_up_screen.dart
+++ b/lib/src/screens/auth/views/sign_up_screen.dart
@@ -42,6 +42,15 @@ class _SignUpScreenState extends State<SignUpScreen> {
 					  signUpRequired = true;
 					});
 				} else if(state is SignUpFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Sign-Up Failed: ${state.error}'),
+              backgroundColor: Colors.red,
+            )
+          );
+          setState(() {
+            signUpRequired = false;
+          });
 					return;
 				} 
 			},

--- a/lib/src/screens/auth/views/sign_up_screen.dart
+++ b/lib/src/screens/auth/views/sign_up_screen.dart
@@ -44,14 +44,13 @@ class _SignUpScreenState extends State<SignUpScreen> {
 				} else if(state is SignUpFailure) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('Sign-Up Failed: ${state.error}'),
+              content: Center(child:Text(state.error)),
               backgroundColor: Colors.red,
             )
           );
           setState(() {
             signUpRequired = false;
           });
-					return;
 				} 
 			},
 			child: Form(

--- a/packages/user_repository/lib/src/firebase_user_repo.dart
+++ b/packages/user_repository/lib/src/firebase_user_repo.dart
@@ -37,6 +37,12 @@ class FirebaseUserRepo implements UserRepository{
   @override
   Future<MyUser> signUp(MyUser myUser, String password) async {
     try{
+      // Check if the email already exists
+      bool emailExists = await checkEmailExists(myUser.email);
+      if(emailExists) {
+        throw Exception('Email already exists');
+      }
+
       UserCredential user = await _firebaseAuth.createUserWithEmailAndPassword(
         email: myUser.email,
         password: password
@@ -66,5 +72,13 @@ class FirebaseUserRepo implements UserRepository{
       rethrow;
     }
   }
-  
+  // HELPER FUNCTIONS
+  Future<bool> checkEmailExists(String email) async {
+    QuerySnapshot <Map<String, dynamic>> query = await usersCollection
+      .where('email', isEqualTo: email)
+      .limit(1)
+      .get();
+
+    return query.docs.isNotEmpty;
+  }
 }


### PR DESCRIPTION
Previously the app would get stuck on the loading state when a user tried to sign up with an email that already existed in the database. 

This issue is now fixed. There is a message shown at the bottom of the screen. The user is allowed to change their email without having to rewrite everything and once again click the sign_up button.